### PR TITLE
feat: add an option to exclude packages from freezing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ poetry build
 # add freeze step
 poetry freeze-wheel
 
-# Note we can't use poetry to publish because it uses metadata from pyproject.toml instead 
+# avoid freezing specific packages
+poetry freeze-wheel --exclude boto3 -e attrs
+
+# Note we can't use poetry to publish because it uses metadata from pyproject.toml instead
 # of frozen wheel metadata.
 
 # publish per normal

--- a/src/poetry_plugin_freeze/app.py
+++ b/src/poetry_plugin_freeze/app.py
@@ -81,7 +81,7 @@ def get_sha256_digest(content: bytes):
 class IcedPoet:
     factory = Factory()
 
-    def __init__(self, project_dir, wheel_dir="dist", exclude_packages=None):
+    def __init__(self, project_dir, wheel_dir="dist", exclude_packages=()):
         self.project_dir = project_dir
         self.wheel_dir = wheel_dir
         self.poetry = self.factory.create_poetry(project_dir)
@@ -219,7 +219,7 @@ class IcedPoet:
             freeze_extras = "base" not in dependency_sources.get(dep_package.dependency.name, set())
             requirement = dep_package.dependency.to_pep_508(with_extras=freeze_extras)
 
-            if exclude_packages and dep_package.package.name in exclude_packages:
+            if dep_package.package.name in exclude_packages:
                 lines.append(requirement)
                 continue
 

--- a/src/poetry_plugin_freeze/app.py
+++ b/src/poetry_plugin_freeze/app.py
@@ -31,6 +31,7 @@ class FreezeCommand(Command):
         option("wheel-dir", None, "Sub-directory containing wheels", flag=False),
         option(
             "exclude",
+            short_name="-e",
             description="A package name to exclude from freezing",
             flag=False,
             value_required=False,

--- a/src/poetry_plugin_freeze/app.py
+++ b/src/poetry_plugin_freeze/app.py
@@ -27,7 +27,16 @@ from poetry_plugin_export.walker import get_project_dependency_packages, walk_de
 class FreezeCommand(Command):
     name = "freeze-wheel"
 
-    options = [option("wheel-dir", None, "Sub-directory containing wheels")]
+    options = [
+        option("wheel-dir", None, "Sub-directory containing wheels", flag=False),
+        option(
+            "exclude",
+            description="A package name to exclude from freezing",
+            flag=False,
+            value_required=False,
+            multiple=True,
+        ),
+    ]
 
     def handle(self) -> int:
         self.line("freezing wheels")
@@ -35,7 +44,7 @@ class FreezeCommand(Command):
 
         fridge = {}
         for project_root in project_roots(root_dir):
-            iced = IcedPoet(project_root)
+            iced = IcedPoet(project_root, self.option("wheel-dir"), self.option("exclude"))
             iced.check()
             fridge[iced.name] = iced
 
@@ -71,12 +80,13 @@ def get_sha256_digest(content: bytes):
 class IcedPoet:
     factory = Factory()
 
-    def __init__(self, project_dir, wheel_dir="dist"):
+    def __init__(self, project_dir, wheel_dir="dist", exclude_packages=None):
         self.project_dir = project_dir
         self.wheel_dir = wheel_dir
         self.poetry = self.factory.create_poetry(project_dir)
         self.meta = Metadata.from_package(self.poetry.package)
         self.fridge = None
+        self.exclude_packages = exclude_packages
 
     def set_fridge(self, fridge):
         self.fridge = fridge
@@ -197,17 +207,22 @@ class IcedPoet:
             new_marker = MultiMarker(new_marker, extra_markers)
         dependency.marker = new_marker
 
-    def get_frozen_deps(self, dep_packages):
+    def get_frozen_deps(self, dep_packages, exclude_packages=None):
         lines = []
         dependency_sources = self.get_dependency_sources()
         for pkg_name, dep_package in dep_packages.items():
             self.compact_markers(dep_package.dependency)
-            require_dist = "%s (==%s)" % (pkg_name, dep_package.package.version)
             # Freeze extra markers for dependencies which were pulled in via extras
             # Don't freeze markers if a dependency is also part of the base
             # dependency tree.
             freeze_extras = "base" not in dependency_sources.get(dep_package.dependency.name, set())
             requirement = dep_package.dependency.to_pep_508(with_extras=freeze_extras)
+
+            if exclude_packages and dep_package.package.name in exclude_packages:
+                lines.append(requirement)
+                continue
+
+            require_dist = "%s (==%s)" % (pkg_name, dep_package.package.version)
             if ";" in requirement:
                 markers = requirement.split(";", 1)[1].strip()
                 require_dist += f" ; {markers}"
@@ -277,7 +292,7 @@ class IcedPoet:
             dist_meta = Parser().parsestr(md_text)
             deps = self.get_path_deps(MAIN_GROUP)
             deps.update(dep_packages)
-            dep_lines = self.get_frozen_deps(deps)
+            dep_lines = self.get_frozen_deps(deps, self.exclude_packages)
             self.replace_deps(dist_meta, dep_lines)
 
             with source_whl.open(record_path) as record_fh:

--- a/src/poetry_plugin_freeze/app.py
+++ b/src/poetry_plugin_freeze/app.py
@@ -28,7 +28,7 @@ class FreezeCommand(Command):
     name = "freeze-wheel"
 
     options = [
-        option("wheel-dir", None, "Sub-directory containing wheels", flag=False),
+        option("wheel-dir", None, "Sub-directory containing wheels", default="dist", flag=False),
         option(
             "exclude",
             short_name="-e",

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -47,10 +47,14 @@ def test_freeze_command_options(fixture_root, monkeypatch):
 
     cmd = app.find("freeze-wheel")
     tester = CommandTester(cmd)
-    tester.execute("--exclude boto3 -e attrs --wheel-dir mydir")
 
+    tester.execute("--exclude boto3 -e attrs --wheel-dir mydir")
     assert poet_options["wheel_dir"] == "mydir"
     assert poet_options["exclude_packages"] == ["boto3", "attrs"]
+
+    tester.execute()
+    assert poet_options["wheel_dir"] == "dist"
+    assert poet_options["exclude_packages"] == []
 
 
 def test_freeze_nested(fixture_root, fixture_copy):


### PR DESCRIPTION
It's useful to be able to freeze _most_ dependencies but leave specific packages with deliberately looser/intact version constraints.

Testing from the command level seems necessary (with or without the motivation of coverage failures), but it's definitely more awkward. Tried to cobble together the minimum useful test based on looking at resources like:

- Cleo's [testing commands](https://cleo.readthedocs.io/en/latest/introduction.html#testing-commands) docs
- How [poetry-plugin-export](https://github.com/python-poetry/poetry-plugin-export) [builds](https://github.com/python-poetry/poetry-plugin-export/blob/main/tests/command/conftest.py) on top of Cleo's base testing support

That command-level test feels like it could be made clearer/simpler/better, but at this point I'm not sure how :thinking: 