### PR TITLE
chore: bump version for 1.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-freeze"
-version = "1.0.5"
+version = "1.0.6"
 description = "Poetry plugin to freeze a wheel's dependencies per lock file"
 license = "Apache-2.0"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]


### PR DESCRIPTION
Can push the tag afterward to trigger an automated release.