### PR TITLE
keep path dependency as such, refering to it via file://

### DIFF
--- a/src/poetry_plugin_freeze/app.py
+++ b/src/poetry_plugin_freeze/app.py
@@ -223,7 +223,10 @@ class IcedPoet:
                 lines.append(requirement)
                 continue
 
-            require_dist = "%s (==%s)" % (pkg_name, dep_package.package.version)
+            if dep_package.package.source_type != "directory":
+                require_dist = "%s (==%s)" % (pkg_name, dep_package.package.version)
+            else:
+                require_dist = "%s @ file://%s" % (pkg_name, dep_package.package.source_url)
             if ";" in requirement:
                 markers = requirement.split(";", 1)[1].strip()
                 require_dist += f" ; {markers}"


### PR DESCRIPTION
### What problem is solved

When using local "path" dependencies in a python mono-repo, `poetry-plugin-freeze` removes the reference to the path and insert the package the same way, as any other package available on pip.

When then trying to use the wheel file, it cannot be installed because the path dependency cannot be found (its not available on pip, and the local path reference is lost).

### What is the solution in this PR

This PR changes the behavior, so that for path-dependencies no version restriction is inserted (there is only one version available) and the reference to the local package (via file://) is preserved.

### Status

- [x] implement feature/update
- [ ] add test cases